### PR TITLE
fix: Correct the spelling of CSS

### DIFF
--- a/apps/image-editor/src/css/range.styl
+++ b/apps/image-editor/src/css/range.styl
@@ -5,7 +5,7 @@
     .{prefix}-virtual-range-subbar
     .{prefix}-virtual-range-pointer
         .{prefix}-disabled
-            backbround-color: red;
+            background-color: red;
 
     .{prefix}-range
         position: relative;


### PR DESCRIPTION
fix: Correct the spelling of CSS, backbround-color change to background-color
